### PR TITLE
Haml lint line length

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,3 @@
+linters:
+  LineLength:
+    max: 100

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,8 @@
 ruby:
   config_file: .rubocop.yml
 
+haml:
+  config_file: .haml-lint.yml
+
 slim_lint:
   enabled: true


### PR DESCRIPTION
Hound needs to stop with the 80 character comments for haml.
