### PR TITLE
Removed unused linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1168,11 +1168,6 @@ Lint/HandleExceptions:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false
 
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace
-    character.
-  Enabled: false
-
 Lint/LiteralInCondition:
   Description: Checks of literals used in conditions.
   Enabled: false


### PR DESCRIPTION
Update config to stop hound giving us warnings about the unused linter.
https://github.com/bbatsov/rubocop/pull/4746/files