### PR TITLE
Further update our config for new rubocop warnings and style changes.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -168,10 +168,6 @@ Style/Encoding:
   Description: Use UTF-8 as the source file encoding.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
   Enabled: false
-  EnforcedStyle: always
-  SupportedStyles:
-  - when_needed
-  - always
 
 Naming/FileName:
   Description: Use snake_case for source file names.


### PR DESCRIPTION
This will remove the warning hound likes to send to us when checking pull requests.