### PR TITLE
enable numerical literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -298,7 +298,7 @@ Layout/MultilineMethodCallIndentation:
 Style/NumericLiterals:
   Description: Add underscores to large numeric literals to improve their readability.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
-  Enabled: false
+  Enabled: true
   MinDigits: 5
 
 Style/ParenthesesAroundCondition:


### PR DESCRIPTION
Enabling `NumericalLiterals` linter. Following the default convention of 5 digits. Which I think made sense.

E.g.
`1000` -> don't prompt to separate with underscore
`10000` -> Prompt to separate with underscore and change it to `10_000`