### PR TITLE
Use consistent_comma for hash and array

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -495,7 +495,7 @@ Style/TrailingCommaInArrayLiteral:
   Description: 'Checks for trailing comma in array and hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: consistent_comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
@@ -505,7 +505,7 @@ Style/TrailingCommaInArrayLiteral:
     Description: 'Checks for trailing comma in array and hash literals.'
     StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
     Enabled: false
-    EnforcedStyleForMultiline: no_comma
+    EnforcedStyleForMultiline: consistent_comma
     SupportedStylesForMultiline:
     - comma
     - consistent_comma


### PR DESCRIPTION
Use consistent_comma for hash and array
- TrailingCommaInHashLiteral and TrailingCommaInArrayLiteral

By having trailing comma, it's easier to re-arrange the order or adding new items without having an error and burden of adding that comma. 

Actually, the ESLint rule which Airbnb uses also encourages the trailing comma.
https://github.com/airbnb/javascript#commas--dangling

Referenced Rubocop doc
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInArrayLiteral

```ruby
# good
a = [
  1,
  2,
]

b = {
  key1: '11',
  key2: '22',
}
```